### PR TITLE
fix exception ViewData["Index"] when null and vertical-align for link in user-satisfaction-response

### DIFF
--- a/src/DSF.AspNetCore.Web.Template/Pages/Shared/_Layout.cshtml
+++ b/src/DSF.AspNetCore.Web.Template/Pages/Shared/_Layout.cshtml
@@ -12,7 +12,7 @@
     {
         lang = "en";
     }
-    string index = ViewData["Index"].ToString() ?? "";
+    string index = ViewData["Index"]?.ToString() ?? "";
 }
 <!DOCTYPE html>
 

--- a/src/DSF.AspNetCore.Web.Template/Pages/Shared/_LayoutNoBackLink.cshtml
+++ b/src/DSF.AspNetCore.Web.Template/Pages/Shared/_LayoutNoBackLink.cshtml
@@ -11,7 +11,7 @@
     {
         lang = "en";
     }
-     string index = ViewData["Index"].ToString() ?? "";
+     string index = ViewData["Index"]?.ToString() ?? "";
 }
 <!DOCTYPE html>
 <html lang="@lang">
@@ -103,8 +103,8 @@
                             <li><a href="/accessibility-statement">@Localizer["common.footer_accesibility"]</a></li>
                             @if (User?.Identity?.IsAuthenticated == true)
                             {
-                            var currentPageUri = new Uri($"{Context.Request.Scheme}://{Context.Request.Host}{Context.Request.Path}");
-                            <li><a href="/user-satisfaction?pageSource=@currentPageUri.PathAndQuery">@Localizer["common.footer_feedback"]</a></li>
+                                var currentPageUri = new Uri($"{Context.Request.Scheme}://{Context.Request.Host}{Context.Request.Path}");
+                                <li><a href="/user-satisfaction?pageSource=@currentPageUri.PathAndQuery">@Localizer["common.footer_feedback"]</a></li>
                             }
                             <li class="govcy-d-block govcy-text-dark">© @Localizer["common.footer_copyright"]</li>
                         </ul>

--- a/src/DSF.AspNetCore.Web.Template/Pages/UserSatisfactionResponse.cshtml
+++ b/src/DSF.AspNetCore.Web.Template/Pages/UserSatisfactionResponse.cshtml
@@ -11,8 +11,10 @@
             <h1>@Localizer["user-satisfaction-response.Success_title"]</h1>
         </div>
     </div>
-    @Localizer.GetPagesLocalizedHtml("user-satisfaction-response.Success_body");
-
-    <a href="@Model.PageSource">@Localizer["common.button_continue_application"]</a>
-
+    <p>
+        @Localizer.GetPagesLocalizedHtml("user-satisfaction-response.Success_body");
+    </p>
+    <p>
+        <a href="@Model.PageSource">@Localizer["common.button_continue_application"]</a>
+    </p>
 </div>


### PR DESCRIPTION
fix(robot-links): got exception when ViewData["Index"] was null
feat(user-satisfaction): vertical-align link on user-satisfaction-response